### PR TITLE
- Added config file to set the "show online timeout" via config

### DIFF
--- a/src/Config/usersonline.php
+++ b/src/Config/usersonline.php
@@ -1,0 +1,20 @@
+<?php
+/*
+* File:     usersonline.php
+* Category: config
+* Author:   s. Schenker
+* Created:  28.06.18
+*/
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Online Timeout (Minutes)
+    |--------------------------------------------------------------------------
+    |
+    | User will show as online until this inactivity timeout
+    |
+    */
+    'online_timeout' => env('USER_ONLINE_TIMEOUT', 10)
+];

--- a/src/Middleware/UsersOnline.php
+++ b/src/Middleware/UsersOnline.php
@@ -19,7 +19,7 @@ class UsersOnline
         $response = $next($request);
 
         if (Auth::user()) {
-            Auth::user()->setCache(config('session.lifetime'));
+            Auth::user()->setCache(config('usersonline.online_timeout'));
         }
 
         return $response;

--- a/src/UsersOnlineServiceProvider.php
+++ b/src/UsersOnlineServiceProvider.php
@@ -13,6 +13,9 @@ class UsersOnlineServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        $this->publishes([
+            __DIR__.'/Config/usersonline.php' => config_path('usersonline.php'),
+        ]);
     }
 
     /**
@@ -22,6 +25,6 @@ class UsersOnlineServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->mergeConfigFrom(__DIR__.'/Config/usersonline.php', 'usersonline');
     }
 }
-


### PR DESCRIPTION
Users should be shown online as long as they are active on the page.
For this reason i have added a separate config for use as "activity timeout".