### PR TITLE
Forced Cache driver as File

### DIFF
--- a/src/Traits/UsersOnlineTrait.php
+++ b/src/Traits/UsersOnlineTrait.php
@@ -14,7 +14,7 @@ trait UsersOnlineTrait
 
     public function isOnline()
     {
-        return Cache::has($this->getCacheKey());
+        return Cache::driver('file')->has($this->getCacheKey());
     }
 
     public function leastRecentOnline()
@@ -35,7 +35,7 @@ trait UsersOnlineTrait
 
     public function getCachedAt()
     {
-        if (empty($cache = Cache::get($this->getCacheKey()))) {
+        if (empty($cache = Cache::driver('file')->get($this->getCacheKey()))) {
             return 0;
         }
 
@@ -44,7 +44,7 @@ trait UsersOnlineTrait
 
     public function setCache($seconds = 300)
     {
-        return Cache::put(
+        return Cache::driver('file')->put(
             $this->getCacheKey(),
             $this->getCacheContent(),
             $seconds
@@ -53,7 +53,7 @@ trait UsersOnlineTrait
 
     public function getCacheContent()
     {
-        if (!empty($cache = Cache::get($this->getCacheKey()))) {
+        if (!empty($cache = Cache::driver('file')->get($this->getCacheKey()))) {
             return $cache;
         }
         $cachedAt = Carbon::now();
@@ -66,7 +66,7 @@ trait UsersOnlineTrait
 
     public function pullCache()
     {
-        Cache::pull($this->getCacheKey());
+        Cache::driver('file')->pull($this->getCacheKey());
     }
 
     public function getCacheKey()


### PR DESCRIPTION
This fix avoids conflicts with other libraries that uses tags based cache drivers (like Redis or Array), not supported by file cache, required for laravel-users-online library for work.

Fixes #80 